### PR TITLE
Add kotlinc_plugins option to kotlin_library().

### DIFF
--- a/docs/rule/kotlin_library.soy
+++ b/docs/rule/kotlin_library.soy
@@ -69,7 +69,57 @@ the <code>resources</code> argument.
 {/call}
 
 {call buck.arg}
-  {param name: 'extra_arguments' /}
+  {param name: 'kotlinc_plugins' /}
+  {param default: '[]' /}
+  {param desc}
+  Use this to specify <a href="https://kotlinlang.org/docs/reference/compiler-plugins.html">
+  Kotlin compiler plugins</a> to use when compiling this library.
+  This takes a list of source paths, each of which will be prefixed
+  with <code>-Xplugin=</code> and passed as extra arguments to the compiler.
+  Unlike <code>extra_kotlinc_arguments</code>, these can be <em>source paths</em>,
+  not just strings (though <code>extra_kotlinc_arguments</code> should be used
+  to specify plugin compiler options with <code>-P</code>).
+  <p>
+  For example, if you want to use{sp}
+  <a href="https://github.com/Kotlin/kotlinx.serialization">kotlinx.serialization</a>
+  {sp}with <code>kotlin_library()</code>, you need to specify{sp}
+  <code>kotlinx-serialization-compiler-plugin.jar</code> under{sp}
+  <code>kotlinc_plugins</code> and <code>kotlinx-serialization-runtime.jar</code>{sp}
+  (which you may have to fetch from Maven) in your <code>deps</code>:
+{literal}<pre class="prettyprint lang-py">
+kotlin_library(
+    name = "example",
+    srcs = glob(["*.kt"]),
+    deps = [
+        ":kotlinx-serialization-runtime",
+    ],
+    kotlinc_plugins = [
+        # Likely copied from your $KOTLIN_HOME directory.
+        "kotlinx-serialization-compiler-plugin.jar",
+    ],
+)
+
+prebuilt_jar(
+    name = "kotlinx-serialization-runtime",
+    binary_jar = ":kotlinx-serialization-runtime-0.10.0",
+)
+
+# Note you probably want to set
+# maven_repo=http://jcenter.bintray.com/ in your .buckconfig until
+# https://github.com/Kotlin/kotlinx.serialization/issues/64
+# is closed.
+remote_file(
+    name = "kotlinx-serialization-runtime-0.10.0",
+    out = "kotlinx-serialization-runtime-0.10.0.jar",
+    url = "mvn:org.jetbrains.kotlinx:kotlinx-serialization-runtime:jar:0.10.0",
+    sha1 = "23d777a5282c1957c7ce35946374fff0adab114c"
+)
+</pre>{/literal}
+  {/param}
+{/call}
+
+{call buck.arg}
+  {param name: 'extra_kotlinc_arguments' /}
   {param default: '[]' /}
   {param desc}
   List of additional arguments to pass into the Kotlin compiler.

--- a/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
@@ -66,6 +66,7 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
     return new KotlincToJarStepFactory(
         kotlinBuckConfig.getKotlinc(),
         kotlinArgs.getExtraKotlincArguments(),
+        kotlinArgs.getKotlincPlugins(),
         kotlinArgs.getFriendPaths(),
         kotlinArgs.getAnnotationProcessingTool().orElse(AnnotationProcessingTool.KAPT),
         extraClasspathProviderSupplier.apply(toolchainProvider),

--- a/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
@@ -199,6 +199,8 @@ public class KotlinLibraryDescription
     Optional<AnnotationProcessingTool> getAnnotationProcessingTool();
 
     ImmutableList<SourcePath> getFriendPaths();
+
+    ImmutableList<SourcePath> getKotlincPlugins();
   }
 
   @BuckStyleImmutable


### PR DESCRIPTION
Summary:
The idea is that you can use the `kotlinc_plugins` option to leverage
something like https://github.com/Kotlin/kotlinx.serialization. Because
`kotlinc_plugins` can also take a build target, you could also define your
own plugin, build it from source, and specify it as an option to
`kotlinc_plugins`.

Complete example:

```
// Example.kt

package com.example

import kotlinx.serialization.Serializable
import kotlinx.serialization.json.Json
import kotlinx.serialization.list

Serializable
data class Foo(val foo: String)

fun yay() {
  val result = Json.parse(Foo.serializer().list, """["foo", "bar"]""")
  println(result)
}
```

```

[download]
maven_repo = http://jcenter.bintray.com/
in_build = true
```

```

kotlin_library(
    name = "example",
    srcs = glob(["*.kt"]),
    deps = [
        ":kotlinx-serialization-runtime",
    ],
    # Note that if any of these plugins took options, you could specify them
    # using `-P` with the `extra_kotlinc_arguments` parameter to kotlin_library().
    kotlinc_plugins = [
        # Does not appear to be available via Maven Central Repo, so it must
        # be checked in.
        "kotlinx-serialization-compiler-plugin.jar",
    ],
)

prebuilt_jar(
    name = "kotlinx-serialization-runtime",
    binary_jar = ":kotlinx-serialization-runtime-0.10.0",
)

remote_file(
    name = "kotlinx-serialization-runtime-0.10.0",
    out = "kotlinx-serialization-runtime-0.10.0.jar",
    url = "mvn:org.jetbrains.kotlinx:kotlinx-serialization-runtime:jar:0.10.0",
    sha1 = "23d777a5282c1957c7ce35946374fff0adab114c"
)
```

Reviewed By: sbalabanov

fbshipit-source-id: de1d4bc34d